### PR TITLE
Add FreeResend launch kit offer

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -184,6 +184,7 @@ vercel --prod
 ## Support
 
 - **Documentation**: Check README.md and SETUP.md
+- **Launch Kit**: Optional deployment checklist at [freeresend.com/launch-kit](https://www.freeresend.com/launch-kit)
 - **Issues**: [GitHub Issues](https://github.com/eibrahim/freeresend/issues)
 - **Professional Support**: [EliteCoders](https://elitecoders.co/)
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ FreeResend allows you to host your own email service using Amazon SES and option
 
 > 📰 **Stay updated**: Get the latest frontend development insights delivered weekly with [**Frontend Weekly**](https://www.frontendweekly.co/) - curated by the author of FreeResend!
 
+> 🧭 **Need a production rollout checklist?** FreeResend stays MIT-licensed and free to self-host. The optional [$12 Self-Hosted Launch Kit](https://www.freeresend.com/launch-kit) gives you a DNS, SES, webhook, smoke-test, and rollback checklist while supporting the project. You can also [buy it directly on Stripe](https://buy.stripe.com/7sY6oJec12WP3i6afQ8so02).
+
 ## Features
 
 - 🚀 **100% Resend-compatible** - True drop-in replacement using environment variables
@@ -402,6 +404,7 @@ MIT License - see LICENSE file for details.
 ## Support
 
 - 📖 **Documentation**: Check SETUP.md for detailed setup instructions
+- 🧭 **Launch Kit**: Optional [$12 self-hosted deployment checklist](https://www.freeresend.com/launch-kit)
 - 🐛 **Issues**: Report bugs via [GitHub Issues](https://github.com/eibrahim/freeresend/issues)
 - 💡 **Feature Requests**: Suggest improvements via GitHub Issues
 - 🚀 **Professional Support**: Custom development and enterprise support available via [EliteCoders](https://elitecoders.co/)

--- a/src/app/launch-kit/download/page.tsx
+++ b/src/app/launch-kit/download/page.tsx
@@ -1,0 +1,120 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { CheckCircle2 } from "lucide-react";
+import LaunchKitPrintButton from "@/components/LaunchKitPrintButton";
+import { launchKit } from "@/config/launch-kit";
+
+export const metadata: Metadata = {
+  title: "FreeResend Launch Kit Checklist",
+  description: "Printable FreeResend deployment checklist for SES, DNS, webhooks, monitoring, and rollout validation.",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+const groups = [
+  {
+    title: "1. Preflight",
+    items: [
+      "Choose the production hostname and confirm HTTPS will terminate before users hit the app.",
+      "Create a production PostgreSQL database and test a direct connection from the deployment environment.",
+      "Generate strong admin and auth secrets; store them in the platform secret manager, not in the repo.",
+      "Confirm the AWS SES region, account sandbox status, and expected monthly sending volume.",
+      "Decide whether DNS records will be created manually or through the DigitalOcean API integration.",
+    ],
+  },
+  {
+    title: "2. DNS and SES",
+    items: [
+      "Verify the sender domain in SES before creating application API keys.",
+      "Publish SES TXT verification, DKIM CNAME records, SPF, and DMARC records.",
+      "Wait for DNS propagation, then use the FreeResend dashboard to re-check domain verification.",
+      "Send test messages to at least two external inbox providers and confirm the sender authentication headers pass.",
+      "Record the exact production sender addresses that applications are allowed to use.",
+    ],
+  },
+  {
+    title: "3. Application rollout",
+    items: [
+      "Run the production build and confirm `/api/health` returns a healthy response.",
+      "Create one production API key per application or environment that will send email.",
+      "Update one low-risk application first with `RESEND_BASE_URL` pointing at FreeResend.",
+      "Send transactional smoke tests for plain text, HTML, and failure cases before broad rollout.",
+      "Keep the prior email provider credentials available until logs show production traffic is stable.",
+    ],
+  },
+  {
+    title: "4. Monitoring and rollback",
+    items: [
+      "Watch SES send, bounce, complaint, and delivery metrics during the first production hour.",
+      "Confirm SES webhook events are reaching FreeResend and failed deliveries appear in logs.",
+      "Set alerts for elevated bounce or complaint rates before increasing traffic.",
+      "Document the rollback variable changes for every application that was migrated.",
+      "Rotate any test or leaked API keys after rollout validation is complete.",
+    ],
+  },
+];
+
+export default function LaunchKitDownloadPage() {
+  return (
+    <main className="min-h-screen bg-gray-50 px-4 py-10 text-gray-900 print:bg-white print:px-0 print:py-0">
+      <article className="mx-auto max-w-4xl rounded-2xl bg-white p-8 shadow-sm print:rounded-none print:p-0 print:shadow-none">
+        <header className="border-b border-gray-200 pb-6">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-wide text-blue-700">FreeResend</p>
+              <h1 className="mt-2 text-3xl font-bold">{launchKit.name}</h1>
+              <p className="mt-3 max-w-2xl text-gray-600">
+                A production checklist for launching the MIT-licensed FreeResend project with Amazon SES, authenticated
+                sender domains, webhook events, and safe rollback coverage.
+              </p>
+            </div>
+            <LaunchKitPrintButton />
+          </div>
+          <p className="mt-5 text-sm text-gray-500 print:hidden">
+            Bought the kit? Save this page as a PDF for your deployment runbook. Previewing first is fine too; the paid
+            checkout is an optional way to support the project.
+          </p>
+        </header>
+
+        <div className="mt-8 space-y-8">
+          {groups.map((group) => (
+            <section key={group.title} className="break-inside-avoid">
+              <h2 className="text-xl font-semibold">{group.title}</h2>
+              <ul className="mt-4 space-y-3">
+                {group.items.map((item) => (
+                  <li key={item} className="flex gap-3">
+                    <span className="mt-0.5 flex h-5 w-5 flex-none items-center justify-center rounded border border-gray-300 print:h-4 print:w-4" />
+                    <span className="leading-7">{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+
+        <section className="mt-10 rounded-xl border border-green-200 bg-green-50 p-5 print:border-gray-300 print:bg-white">
+          <h2 className="flex items-center gap-2 text-lg font-semibold text-green-800 print:text-gray-900">
+            <CheckCircle2 className="h-5 w-5" />
+            Launch complete when
+          </h2>
+          <p className="mt-2 text-green-900 print:text-gray-800">
+            Production applications can send through FreeResend, authenticated headers pass, delivery events are logged,
+            and rollback steps are documented for every migrated sender.
+          </p>
+        </section>
+
+        <footer className="mt-10 border-t border-gray-200 pt-6 text-sm text-gray-500 print:hidden">
+          <Link href="/launch-kit" className="font-medium text-blue-700 hover:text-blue-800">
+            Back to launch kit
+          </Link>
+          <span className="mx-2">/</span>
+          <a href={launchKit.checkoutUrl} className="font-medium text-blue-700 hover:text-blue-800">
+            Buy the optional supporter kit
+          </a>
+        </footer>
+      </article>
+    </main>
+  );
+}

--- a/src/app/launch-kit/page.tsx
+++ b/src/app/launch-kit/page.tsx
@@ -1,0 +1,144 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight, CheckCircle2, ExternalLink, ServerCog, ShieldCheck, Workflow } from "lucide-react";
+import { launchKit } from "@/config/launch-kit";
+
+export const metadata: Metadata = {
+  title: "FreeResend Self-Hosted Launch Kit",
+  description:
+    "A practical deployment checklist for launching FreeResend with Amazon SES, DNS authentication, webhooks, monitoring, and rollback steps.",
+  openGraph: {
+    title: "FreeResend Self-Hosted Launch Kit",
+    description:
+      "Deploy FreeResend with a practical SES, DNS, webhook, monitoring, and rollback checklist.",
+    url: "https://www.freeresend.com/launch-kit",
+    type: "website",
+  },
+};
+
+const sections = [
+  {
+    icon: ServerCog,
+    title: "Infrastructure preflight",
+    copy: "Confirm the database, secrets, AWS region, sending limits, DNS ownership, and deployment target before the first production rollout.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Deliverability setup",
+    copy: "Work through SES verification, DKIM, SPF, DMARC, bounce handling, webhook wiring, and safe sender-domain testing.",
+  },
+  {
+    icon: Workflow,
+    title: "Launch and rollback",
+    copy: "Use smoke tests, monitoring checks, API-key rotation notes, and rollback steps before pointing production apps at FreeResend.",
+  },
+];
+
+export default function LaunchKitPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">
+      <div className="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
+        <nav className="mb-10 flex items-center justify-between">
+          <Link href="/" className="text-sm font-medium text-gray-600 hover:text-gray-900">
+            FreeResend
+          </Link>
+          <a
+            href="https://github.com/eibrahim/freeresend"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm font-medium text-gray-600 hover:text-gray-900"
+          >
+            GitHub
+          </a>
+        </nav>
+
+        <section className="grid gap-10 lg:grid-cols-[1.15fr_0.85fr] lg:items-center">
+          <div>
+            <div className="mb-5 inline-flex items-center rounded-full border border-blue-100 bg-white px-3 py-1 text-sm font-medium text-blue-700 shadow-sm">
+              Optional {launchKit.price} supporter kit
+            </div>
+            <h1 className="text-4xl font-bold leading-tight text-gray-900 sm:text-5xl">
+              Ship FreeResend without missing the SES and DNS details.
+            </h1>
+            <p className="mt-5 text-lg leading-8 text-gray-600">
+              The open-source FreeResend repo stays MIT-licensed and free to self-host. This launch kit gives you a
+              practical checklist for the parts that usually slow down production email rollouts: authentication records,
+              SES limits, webhook events, smoke tests, and rollback planning.
+            </p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <a
+                href={launchKit.checkoutUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-blue-700"
+              >
+                <span>Buy for {launchKit.price}</span>
+                <ExternalLink className="h-4 w-4" />
+              </a>
+              <Link
+                href="/launch-kit/download"
+                className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-6 py-3 font-semibold text-gray-700 transition-colors hover:border-gray-300"
+              >
+                <span>Preview checklist</span>
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </div>
+            <p className="mt-4 text-sm text-gray-500">
+              Stripe checkout redirects to the printable kit. You can also preview it before buying.
+            </p>
+          </div>
+
+          <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+            <div className="border-b border-gray-100 pb-4">
+              <p className="text-sm font-medium uppercase tracking-wide text-blue-700">Included checklist</p>
+              <h2 className="mt-2 text-2xl font-bold text-gray-900">{launchKit.name}</h2>
+            </div>
+            <ul className="mt-6 space-y-4">
+              {launchKit.bullets.map((item) => (
+                <li key={item} className="flex gap-3 text-gray-700">
+                  <CheckCircle2 className="mt-0.5 h-5 w-5 flex-none text-green-600" />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        <section className="mt-16 grid gap-5 md:grid-cols-3">
+          {sections.map((section) => {
+            const Icon = section.icon;
+            return (
+              <div key={section.title} className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+                <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-lg bg-blue-50 text-blue-700">
+                  <Icon className="h-5 w-5" />
+                </div>
+                <h2 className="text-lg font-semibold text-gray-900">{section.title}</h2>
+                <p className="mt-2 text-sm leading-6 text-gray-600">{section.copy}</p>
+              </div>
+            );
+          })}
+        </section>
+
+        <section className="mt-16 rounded-2xl bg-gray-900 p-8 text-white">
+          <div className="grid gap-8 lg:grid-cols-[1fr_auto] lg:items-center">
+            <div>
+              <h2 className="text-2xl font-bold">Need implementation help instead of a checklist?</h2>
+              <p className="mt-2 text-gray-300">
+                For custom deployment, scaling, or integration work, use the professional support path through EliteCoders.
+              </p>
+            </div>
+            <a
+              href="https://elitecoders.co/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-5 py-3 font-semibold text-gray-900 transition-colors hover:bg-gray-100"
+            >
+              <span>Contact EliteCoders</span>
+              <ExternalLink className="h-4 w-4" />
+            </a>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import PricingCalculator from '../../components/PricingCalculator';
+import LaunchKitCta from '../../components/LaunchKitCta';
 
 export const metadata: Metadata = {
   title: 'Pricing Calculator - FreeResend',
@@ -34,6 +35,10 @@ export default function PricingPage() {
 
         {/* Pricing Calculator */}
         <PricingCalculator />
+
+        <div className="mt-12">
+          <LaunchKitCta />
+        </div>
 
         {/* Key Benefits */}
         <div className="mt-16 grid md:grid-cols-3 gap-8">

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,28 @@
+import type { MetadataRoute } from "next";
+
+const baseUrl = "https://www.freeresend.com";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/pricing`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/launch-kit`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+  ];
+}

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import {
   ArrowRight,
+  BookOpenCheck,
   Code,
   DollarSign,
   Globe,
@@ -15,6 +16,8 @@ import {
   CheckCircle,
 } from "lucide-react";
 import EnvelopeIcon from "./EnvelopeIcon";
+import LaunchKitCta from "./LaunchKitCta";
+import { launchKit } from "@/config/launch-kit";
 
 export default function LandingPage() {
   const [copiedCode, setCopiedCode] = useState(false);
@@ -52,6 +55,12 @@ export default function LandingPage() {
                 <span className="hidden sm:inline">GitHub</span>
               </a>
               <Link
+                href={launchKit.productUrl}
+                className="hidden text-gray-600 transition-colors hover:text-gray-900 md:inline"
+              >
+                Launch Kit
+              </Link>
+              <Link
                 href="/login"
                 className="text-gray-600 hover:text-gray-900 transition-colors px-3 py-2"
               >
@@ -59,9 +68,10 @@ export default function LandingPage() {
               </Link>
               <Link
                 href="/pricing"
-                className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors flex items-center space-x-2"
+                aria-label="Join Waitlist"
+                className="bg-blue-600 text-white px-3 sm:px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors flex items-center space-x-2"
               >
-                <span>Join Waitlist</span>
+                <span className="hidden sm:inline">Join Waitlist</span>
                 <ArrowRight className="h-4 w-4" />
               </Link>
             </div>
@@ -116,6 +126,13 @@ export default function LandingPage() {
               <Github className="h-5 w-5" />
               <span>View on GitHub</span>
             </a>
+            <Link
+              href={launchKit.productUrl}
+              className="border-2 border-gray-200 bg-white text-gray-700 px-8 py-4 rounded-lg hover:border-gray-300 transition-colors flex items-center justify-center space-x-2 font-semibold"
+            >
+              <BookOpenCheck className="h-5 w-5" />
+              <span>Launch Kit</span>
+            </Link>
           </div>
           
           <div className="text-center mb-8">
@@ -162,9 +179,13 @@ export default function LandingPage() {
             </div>
           </div>
 
+          <div className="mx-auto mb-12 max-w-4xl text-left">
+            <LaunchKitCta compact />
+          </div>
+
           {/* Migration Code Example */}
           <div className="max-w-2xl mx-auto">
-            <div className="bg-gray-900 rounded-lg p-6 text-left">
+            <div className="bg-gray-900 rounded-lg p-6 text-left overflow-x-auto">
               <div className="flex items-center justify-between mb-4">
                 <span className="text-gray-400 text-sm">
                   Migration is literally one line:
@@ -180,7 +201,7 @@ export default function LandingPage() {
                   )}
                 </button>
               </div>
-              <code className="text-green-400 font-mono text-sm block">
+              <code className="text-green-400 font-mono text-sm block whitespace-nowrap">
                 RESEND_BASE_URL=&quot;https://freeresend.com/api&quot;
               </code>
               <p className="text-gray-400 text-sm mt-2">
@@ -484,6 +505,14 @@ export default function LandingPage() {
             <div>
               <h5 className="font-semibold mb-4">Resources</h5>
               <ul className="space-y-2">
+                <li>
+                  <Link
+                    href={launchKit.productUrl}
+                    className="text-gray-400 hover:text-white transition-colors"
+                  >
+                    Launch Kit
+                  </Link>
+                </li>
                 <li>
                   <a
                     href="https://github.com/eibrahim/freeresend"

--- a/src/components/LaunchKitCta.tsx
+++ b/src/components/LaunchKitCta.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+import { ArrowRight, CheckCircle2, ClipboardCheck, ExternalLink } from "lucide-react";
+import { launchKit } from "@/config/launch-kit";
+
+type LaunchKitCtaProps = {
+  compact?: boolean;
+};
+
+export default function LaunchKitCta({ compact = false }: LaunchKitCtaProps) {
+  return (
+    <section className={compact ? "rounded-lg border border-blue-100 bg-white p-6 shadow-sm" : "rounded-2xl border border-blue-100 bg-white p-8 shadow-sm"}>
+      <div className={compact ? "space-y-5" : "grid gap-8 lg:grid-cols-[1.25fr_0.75fr] lg:items-center"}>
+        <div>
+          <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-blue-100 bg-blue-50 px-3 py-1 text-sm font-medium text-blue-700">
+            <ClipboardCheck className="h-4 w-4" />
+            Optional supporter kit
+          </div>
+          <h2 className={compact ? "text-2xl font-bold text-gray-900" : "text-3xl font-bold text-gray-900"}>
+            Deploy FreeResend with fewer missed setup steps.
+          </h2>
+          <p className="mt-3 text-gray-600">
+            The MIT project remains free. The {launchKit.price} launch kit is an optional checklist for teams that want a tighter
+            SES, DNS, webhook, and production rollout path while supporting the project.
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          <ul className="space-y-2 text-sm text-gray-700">
+            {launchKit.bullets.slice(0, compact ? 3 : launchKit.bullets.length).map((item) => (
+              <li key={item} className="flex gap-2">
+                <CheckCircle2 className="mt-0.5 h-4 w-4 flex-none text-green-600" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <a
+              href={launchKit.checkoutUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-5 py-3 font-semibold text-white transition-colors hover:bg-blue-700"
+            >
+              <span>Buy for {launchKit.price}</span>
+              <ExternalLink className="h-4 w-4" />
+            </a>
+            <Link
+              href={launchKit.productUrl}
+              className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-200 px-5 py-3 font-semibold text-gray-700 transition-colors hover:border-gray-300 hover:bg-gray-50"
+            >
+              <span>Preview kit</span>
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/LaunchKitPrintButton.tsx
+++ b/src/components/LaunchKitPrintButton.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { Printer } from "lucide-react";
+
+export default function LaunchKitPrintButton() {
+  return (
+    <button
+      type="button"
+      onClick={() => window.print()}
+      className="inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-5 py-3 font-semibold text-white transition-colors hover:bg-blue-700 print:hidden"
+    >
+      <Printer className="h-4 w-4" />
+      <span>Print or save PDF</span>
+    </button>
+  );
+}

--- a/src/config/launch-kit.ts
+++ b/src/config/launch-kit.ts
@@ -1,0 +1,16 @@
+export const launchKit = {
+  name: "FreeResend Self-Hosted Launch Kit",
+  price: "$12",
+  productUrl: "/launch-kit",
+  downloadUrl: "/launch-kit/download?purchase=success",
+  checkoutUrl: "https://buy.stripe.com/7sY6oJec12WP3i6afQ8so02",
+  stripePaymentLinkId: "plink_1TbzL1PumRNTtKWj9H06DvKY",
+  stripeProductId: "prod_UbBiFZ4xQHw97Z",
+  stripePriceId: "price_1TbzKqPumRNTtKWjlaIdDWsw",
+  bullets: [
+    "DNS, SES, DKIM, SPF, and DMARC launch checklist",
+    "Production environment and webhook rollout checks",
+    "Deliverability smoke-test script outline",
+    "Incident rollback and monitoring checklist",
+  ],
+} as const;


### PR DESCRIPTION
## Summary
- add an optional  Self-Hosted Launch Kit product/download route
- promote the launch kit from the homepage, pricing page, README, and deployment docs
- add sitemap coverage for the public launch-kit page while keeping the download page noindex

## Verification
- npm run lint
- npm run build
- NODE_OPTIONS=--max-old-space-size=2048 npx jest src/components/__tests__/LandingPage.test.tsx --runInBand
- git diff --check
- local headless browser smoke for homepage, pricing, /launch-kit, /launch-kit/download, and /sitemap.xml