### PR TITLE
Guard launch kit download route

### DIFF
--- a/src/app/launch-kit/download/page.tsx
+++ b/src/app/launch-kit/download/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { redirect } from "next/navigation";
 import { CheckCircle2 } from "lucide-react";
 import LaunchKitPrintButton from "@/components/LaunchKitPrintButton";
 import { launchKit } from "@/config/launch-kit";
@@ -56,7 +57,18 @@ const groups = [
   },
 ];
 
-export default function LaunchKitDownloadPage() {
+export default async function LaunchKitDownloadPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = await searchParams;
+  const purchase = typeof params.purchase === "string" ? params.purchase : undefined;
+
+  if (purchase !== "success") {
+    redirect(launchKit.productUrl);
+  }
+
   return (
     <main className="min-h-screen bg-gray-50 px-4 py-10 text-gray-900 print:bg-white print:px-0 print:py-0">
       <article className="mx-auto max-w-4xl rounded-2xl bg-white p-8 shadow-sm print:rounded-none print:p-0 print:shadow-none">

--- a/src/app/launch-kit/page.tsx
+++ b/src/app/launch-kit/page.tsx
@@ -76,19 +76,19 @@ export default function LaunchKitPage() {
                 <ExternalLink className="h-4 w-4" />
               </a>
               <Link
-                href="/launch-kit/download"
+                href="#included-checklist"
                 className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-6 py-3 font-semibold text-gray-700 transition-colors hover:border-gray-300"
               >
-                <span>Preview checklist</span>
+                <span>See what is included</span>
                 <ArrowRight className="h-4 w-4" />
               </Link>
             </div>
             <p className="mt-4 text-sm text-gray-500">
-              Stripe checkout redirects to the printable kit. You can also preview it before buying.
+              Stripe checkout redirects to the printable kit after purchase.
             </p>
           </div>
 
-          <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+          <div id="included-checklist" className="scroll-mt-8 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
             <div className="border-b border-gray-100 pb-4">
               <p className="text-sm font-medium uppercase tracking-wide text-blue-700">Included checklist</p>
               <h2 className="mt-2 text-2xl font-bold text-gray-900">{launchKit.name}</h2>


### PR DESCRIPTION
## Summary
- remove the public preview link from the FreeResend launch-kit sales page
- redirect bare launch-kit download requests back to the product page
- keep the Stripe success URL rendering the printable checklist

## Validation
- npm run lint
- npm run build
- local HTTP smoke: product page has checkout link and no bare download link; bare download returns 307; ?purchase=success returns 200 with checklist content