### PR TITLE
Add FreeResend deployment review offer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ FreeResend allows you to host your own email service using Amazon SES and option
 
 > 🧭 **Need a production rollout checklist?** FreeResend stays MIT-licensed and free to self-host. The optional [$12 Self-Hosted Launch Kit](https://www.freeresend.com/launch-kit) gives you a DNS, SES, webhook, smoke-test, and rollback checklist while supporting the project. You can also [buy it directly on Stripe](https://buy.stripe.com/7sY6oJec12WP3i6afQ8so02).
 
+> 🔎 **Want a second set of eyes before launch?** The optional [$12 FreeResend Deployment Review](https://www.freeresend.com/deployment-review) is a narrow manual review of one self-hosted rollout plan. Stripe collects your deployment URL or GitHub issue and main SES/DNS concern. You can also [book it directly on Stripe](https://buy.stripe.com/5kQ8wR2tj0OHg4S5ZA8so04).
+
 ## Features
 
 - 🚀 **100% Resend-compatible** - True drop-in replacement using environment variables
@@ -405,6 +407,7 @@ MIT License - see LICENSE file for details.
 
 - 📖 **Documentation**: Check SETUP.md for detailed setup instructions
 - 🧭 **Launch Kit**: Optional [$12 self-hosted deployment checklist](https://www.freeresend.com/launch-kit)
+- 🔎 **Deployment Review**: Optional [$12 one-page review of your SES, DNS, webhook, and launch-risk plan](https://www.freeresend.com/deployment-review)
 - 🐛 **Issues**: Report bugs via [GitHub Issues](https://github.com/eibrahim/freeresend/issues)
 - 💡 **Feature Requests**: Suggest improvements via GitHub Issues
 - 🚀 **Professional Support**: Custom development and enterprise support available via [EliteCoders](https://elitecoders.co/)

--- a/src/app/deployment-review/page.tsx
+++ b/src/app/deployment-review/page.tsx
@@ -1,0 +1,132 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { AlertTriangle, CheckCircle2, ExternalLink, MailCheck, Radar, ShieldCheck } from "lucide-react";
+import { deploymentReview, launchKit } from "@/config/launch-kit";
+
+export const metadata: Metadata = {
+  title: "FreeResend Deployment Review",
+  description:
+    "A concise manual review of one FreeResend self-hosted deployment plan covering DNS, SES, webhooks, and launch risk.",
+  openGraph: {
+    title: "FreeResend Deployment Review",
+    description:
+      "Get a narrow FreeResend self-hosting review before sending production email.",
+    url: "https://www.freeresend.com/deployment-review",
+    type: "website",
+  },
+};
+
+const reviewAreas = [
+  {
+    icon: ShieldCheck,
+    title: "DNS authentication",
+    copy: "DKIM, SPF, DMARC, sender domains, and the common record-shape mistakes that hurt deliverability.",
+  },
+  {
+    icon: MailCheck,
+    title: "SES readiness",
+    copy: "Sandbox status, region choice, suppression handling, bounce events, complaint events, and safe test sending.",
+  },
+  {
+    icon: Radar,
+    title: "Launch risk",
+    copy: "Webhook gaps, smoke-test coverage, rollback steps, and the highest-priority fixes before production traffic.",
+  },
+];
+
+export default function DeploymentReviewPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-emerald-50 via-white to-blue-50">
+      <div className="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
+        <nav className="mb-10 flex items-center justify-between">
+          <Link href="/" className="text-sm font-medium text-gray-600 hover:text-gray-900">
+            FreeResend
+          </Link>
+          <Link href={launchKit.productUrl} className="text-sm font-medium text-gray-600 hover:text-gray-900">
+            Launch Kit
+          </Link>
+        </nav>
+
+        <section className="grid gap-10 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
+          <div>
+            <div className="mb-5 inline-flex items-center rounded-full border border-emerald-100 bg-white px-3 py-1 text-sm font-medium text-emerald-700 shadow-sm">
+              {deploymentReview.price} manual deployment review
+            </div>
+            <h1 className="text-4xl font-bold leading-tight text-gray-900 sm:text-5xl">
+              Catch the SES and DNS mistakes before customers see them.
+            </h1>
+            <p className="mt-5 text-lg leading-8 text-gray-600">
+              Send one FreeResend deployment URL, GitHub issue, or rollout note through Stripe checkout. You get a
+              concise review focused on email-authentication risk, SES readiness, webhook coverage, and the next fixes to make.
+            </p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <a
+                href={deploymentReview.checkoutUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 rounded-lg bg-emerald-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-emerald-700"
+              >
+                <span>Book review for {deploymentReview.price}</span>
+                <ExternalLink className="h-4 w-4" />
+              </a>
+              <Link
+                href="#scope"
+                className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-6 py-3 font-semibold text-gray-700 transition-colors hover:border-gray-300"
+              >
+                <span>Review scope</span>
+              </Link>
+            </div>
+            <p className="mt-4 text-sm text-gray-500">
+              Stripe checkout asks for a deployment URL or GitHub issue and your main concern. Do not include AWS keys,
+              SMTP passwords, database credentials, or other secrets.
+            </p>
+          </div>
+
+          <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+            <div className="border-b border-gray-100 pb-4">
+              <p className="text-sm font-medium uppercase tracking-wide text-emerald-700">Included</p>
+              <h2 className="mt-2 text-2xl font-bold text-gray-900">{deploymentReview.name}</h2>
+            </div>
+            <ul className="mt-6 space-y-4">
+              {deploymentReview.bullets.map((item) => (
+                <li key={item} className="flex gap-3 text-gray-700">
+                  <CheckCircle2 className="mt-0.5 h-5 w-5 flex-none text-emerald-600" />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        <section id="scope" className="mt-16 grid gap-5 md:grid-cols-3">
+          {reviewAreas.map((area) => {
+            const Icon = area.icon;
+            return (
+              <div key={area.title} className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+                <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-lg bg-emerald-50 text-emerald-700">
+                  <Icon className="h-5 w-5" />
+                </div>
+                <h2 className="text-lg font-semibold text-gray-900">{area.title}</h2>
+                <p className="mt-2 text-sm leading-6 text-gray-600">{area.copy}</p>
+              </div>
+            );
+          })}
+        </section>
+
+        <section className="mt-16 rounded-2xl border border-amber-200 bg-amber-50 p-8">
+          <div className="flex gap-4">
+            <AlertTriangle className="mt-1 h-6 w-6 flex-none text-amber-700" />
+            <div>
+              <h2 className="text-xl font-bold text-amber-950">Narrow by design</h2>
+              <p className="mt-2 leading-7 text-amber-900">
+                This is a one-page review of one deployment plan, not a full implementation contract, live debugging
+                session, or deliverability guarantee. For custom development, use the professional support path after
+                the review identifies the concrete work.
+              </p>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/deployment-review/thanks/page.tsx
+++ b/src/app/deployment-review/thanks/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { CheckCircle2 } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Deployment Review Received",
+  description: "Confirmation page for the FreeResend Deployment Review.",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function DeploymentReviewThanksPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-emerald-50 via-white to-blue-50">
+      <div className="mx-auto flex min-h-screen max-w-3xl items-center px-4 py-16 sm:px-6">
+        <section className="rounded-2xl border border-gray-200 bg-white p-8 shadow-sm">
+          <div className="mb-5 flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100 text-emerald-700">
+            <CheckCircle2 className="h-7 w-7" />
+          </div>
+          <h1 className="text-3xl font-bold text-gray-900">Your deployment review is in the queue.</h1>
+          <p className="mt-4 leading-7 text-gray-600">
+            The review will use the deployment URL, GitHub issue, and concern you entered in Stripe checkout. Expect a
+            concise written review focused on DNS authentication, SES readiness, webhook coverage, and launch risks.
+          </p>
+          <p className="mt-4 rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm leading-6 text-amber-900">
+            Do not send credentials. If more context is needed, share sanitized config snippets or a public/private GitHub
+            issue link through the same email used at checkout.
+          </p>
+          <div className="mt-7 flex flex-col gap-3 sm:flex-row">
+            <Link
+              href="/deployment-review"
+              className="inline-flex items-center justify-center rounded-lg border border-gray-200 px-5 py-3 font-semibold text-gray-700 transition-colors hover:border-gray-300 hover:bg-gray-50"
+            >
+              Review scope
+            </Link>
+            <Link
+              href="/"
+              className="inline-flex items-center justify-center rounded-lg bg-emerald-600 px-5 py-3 font-semibold text-white transition-colors hover:bg-emerald-700"
+            >
+              Back to FreeResend
+            </Link>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/launch-kit/page.tsx
+++ b/src/app/launch-kit/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { ArrowRight, CheckCircle2, ExternalLink, ServerCog, ShieldCheck, Workflow } from "lucide-react";
-import { launchKit } from "@/config/launch-kit";
+import { deploymentReview, launchKit } from "@/config/launch-kit";
 
 export const metadata: Metadata = {
   title: "FreeResend Self-Hosted Launch Kit",
@@ -124,16 +124,17 @@ export default function LaunchKitPage() {
             <div>
               <h2 className="text-2xl font-bold">Need implementation help instead of a checklist?</h2>
               <p className="mt-2 text-gray-300">
-                For custom deployment, scaling, or integration work, use the professional support path through EliteCoders.
+                Start with a narrow {deploymentReview.price} review of your FreeResend deployment plan before committing
+                to custom work.
               </p>
             </div>
             <a
-              href="https://elitecoders.co/"
+              href={deploymentReview.checkoutUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-5 py-3 font-semibold text-gray-900 transition-colors hover:bg-gray-100"
             >
-              <span>Contact EliteCoders</span>
+              <span>Book deployment review</span>
               <ExternalLink className="h-4 w-4" />
             </a>
           </div>

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import PricingCalculator from '../../components/PricingCalculator';
+import DeploymentReviewCta from '../../components/DeploymentReviewCta';
 import LaunchKitCta from '../../components/LaunchKitCta';
 
 export const metadata: Metadata = {
@@ -38,6 +39,10 @@ export default function PricingPage() {
 
         <div className="mt-12">
           <LaunchKitCta />
+        </div>
+
+        <div className="mt-8">
+          <DeploymentReviewCta />
         </div>
 
         {/* Key Benefits */}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -24,5 +24,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 0.7,
     },
+    {
+      url: `${baseUrl}/deployment-review`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
   ];
 }

--- a/src/components/DeploymentReviewCta.tsx
+++ b/src/components/DeploymentReviewCta.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+import { ArrowRight, CheckCircle2, ExternalLink, Radar } from "lucide-react";
+import { deploymentReview } from "@/config/launch-kit";
+
+type DeploymentReviewCtaProps = {
+  compact?: boolean;
+};
+
+export default function DeploymentReviewCta({ compact = false }: DeploymentReviewCtaProps) {
+  return (
+    <section className={compact ? "rounded-lg border border-emerald-100 bg-white p-6 shadow-sm" : "rounded-2xl border border-emerald-100 bg-white p-8 shadow-sm"}>
+      <div className={compact ? "space-y-5" : "grid gap-8 lg:grid-cols-[1.2fr_0.8fr] lg:items-center"}>
+        <div>
+          <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-emerald-100 bg-emerald-50 px-3 py-1 text-sm font-medium text-emerald-700">
+            <Radar className="h-4 w-4" />
+            Deployment review
+          </div>
+          <h2 className={compact ? "text-2xl font-bold text-gray-900" : "text-3xl font-bold text-gray-900"}>
+            Want a second set of eyes before you send production email?
+          </h2>
+          <p className="mt-3 text-gray-600">
+            Buy a {deploymentReview.price} manual review for one FreeResend deployment plan. Stripe collects your
+            deployment URL or GitHub issue and the main SES/DNS concern; do not send credentials.
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          <ul className="space-y-2 text-sm text-gray-700">
+            {deploymentReview.bullets.slice(0, compact ? 3 : deploymentReview.bullets.length).map((item) => (
+              <li key={item} className="flex gap-2">
+                <CheckCircle2 className="mt-0.5 h-4 w-4 flex-none text-emerald-600" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <a
+              href={deploymentReview.checkoutUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-emerald-600 px-5 py-3 font-semibold text-white transition-colors hover:bg-emerald-700"
+            >
+              <span>Book review for {deploymentReview.price}</span>
+              <ExternalLink className="h-4 w-4" />
+            </a>
+            <Link
+              href={deploymentReview.productUrl}
+              className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-200 px-5 py-3 font-semibold text-gray-700 transition-colors hover:border-gray-300 hover:bg-gray-50"
+            >
+              <span>See scope</span>
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -16,8 +16,9 @@ import {
   CheckCircle,
 } from "lucide-react";
 import EnvelopeIcon from "./EnvelopeIcon";
+import DeploymentReviewCta from "./DeploymentReviewCta";
 import LaunchKitCta from "./LaunchKitCta";
-import { launchKit } from "@/config/launch-kit";
+import { deploymentReview, launchKit } from "@/config/launch-kit";
 
 export default function LandingPage() {
   const [copiedCode, setCopiedCode] = useState(false);
@@ -59,6 +60,12 @@ export default function LandingPage() {
                 className="hidden text-gray-600 transition-colors hover:text-gray-900 md:inline"
               >
                 Launch Kit
+              </Link>
+              <Link
+                href={deploymentReview.productUrl}
+                className="hidden text-gray-600 transition-colors hover:text-gray-900 lg:inline"
+              >
+                Review
               </Link>
               <Link
                 href="/login"
@@ -181,6 +188,10 @@ export default function LandingPage() {
 
           <div className="mx-auto mb-12 max-w-4xl text-left">
             <LaunchKitCta compact />
+          </div>
+
+          <div className="mx-auto mb-12 max-w-4xl text-left">
+            <DeploymentReviewCta compact />
           </div>
 
           {/* Migration Code Example */}
@@ -511,6 +522,14 @@ export default function LandingPage() {
                     className="text-gray-400 hover:text-white transition-colors"
                   >
                     Launch Kit
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href={deploymentReview.productUrl}
+                    className="text-gray-400 hover:text-white transition-colors"
+                  >
+                    Deployment Review
                   </Link>
                 </li>
                 <li>

--- a/src/config/launch-kit.ts
+++ b/src/config/launch-kit.ts
@@ -14,3 +14,20 @@ export const launchKit = {
     "Incident rollback and monitoring checklist",
   ],
 } as const;
+
+export const deploymentReview = {
+  name: "FreeResend Deployment Review",
+  price: "$12",
+  productUrl: "/deployment-review",
+  thanksUrl: "/deployment-review/thanks",
+  checkoutUrl: "https://buy.stripe.com/5kQ8wR2tj0OHg4S5ZA8so04",
+  stripePaymentLinkId: "plink_1Tc184PumRNTtKWjsEn4dgT9",
+  stripeProductId: "prod_UbDZ8ngA9IVDxu",
+  stripePriceId: "price_1Tc17wPumRNTtKWj3MgY7uMl",
+  bullets: [
+    "DNS, DKIM, SPF, and DMARC risk review",
+    "SES sandbox, region, bounce, and complaint checks",
+    "Webhook and smoke-test gaps to fix before launch",
+    "One-page priority report delivered from your Stripe intake",
+  ],
+} as const;


### PR DESCRIPTION
## Summary
- add a  FreeResend Deployment Review product page and post-checkout thank-you page
- add homepage, pricing, launch-kit, README, and sitemap entry points
- point the offer to the live Stripe payment link with checkout intake fields

## Verification
- npm run lint
- npm run build
- git diff --check
- local Playwright checks for /, /deployment-review, /deployment-review/thanks, /pricing, /launch-kit, and sitemap coverage
- Stripe live payment link retrieved and verified active