### PR TITLE
Add email DNS readiness checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ FreeResend allows you to host your own email service using Amazon SES and option
 
 > 🔎 **Want a second set of eyes before launch?** The optional [$12 FreeResend Deployment Review](https://www.freeresend.com/deployment-review) is a narrow manual review of one self-hosted rollout plan. Stripe collects your deployment URL or GitHub issue and main SES/DNS concern. You can also [book it directly on Stripe](https://buy.stripe.com/5kQ8wR2tj0OHg4S5ZA8so04).
 
+> 📬 **Checking DNS before SES launch?** Run the free [Email DNS Readiness Checker](https://www.freeresend.com/tools/email-dns-checker) for SPF, DMARC, DKIM, and MX records before sending production traffic.
+
 ## Features
 
 - 🚀 **100% Resend-compatible** - True drop-in replacement using environment variables
@@ -408,6 +410,7 @@ MIT License - see LICENSE file for details.
 - 📖 **Documentation**: Check SETUP.md for detailed setup instructions
 - 🧭 **Launch Kit**: Optional [$12 self-hosted deployment checklist](https://www.freeresend.com/launch-kit)
 - 🔎 **Deployment Review**: Optional [$12 one-page review of your SES, DNS, webhook, and launch-risk plan](https://www.freeresend.com/deployment-review)
+- 📬 **DNS Checker**: Free [email DNS readiness checker](https://www.freeresend.com/tools/email-dns-checker) for SPF, DMARC, DKIM, and MX records
 - 🐛 **Issues**: Report bugs via [GitHub Issues](https://github.com/eibrahim/freeresend/issues)
 - 💡 **Feature Requests**: Suggest improvements via GitHub Issues
 - 🚀 **Professional Support**: Custom development and enterprise support available via [EliteCoders](https://elitecoders.co/)

--- a/src/app/api/tools/email-dns-checker/route.ts
+++ b/src/app/api/tools/email-dns-checker/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server";
+import { promises as dns } from "node:dns";
+import {
+  analyzeEmailDnsRecords,
+  normalizeDkimSelector,
+  normalizeDomain,
+} from "@/lib/email-dns-readiness";
+
+export const runtime = "nodejs";
+
+type RequestBody = {
+  domain?: unknown;
+  dkimSelector?: unknown;
+};
+
+async function resolveTxt(name: string, errors: string[]): Promise<string[]> {
+  try {
+    const records = await dns.resolveTxt(name);
+    return records.map((parts) => parts.join(""));
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENODATA" || code === "ENOTFOUND" || code === "ENOENT") return [];
+    errors.push(`${name}: TXT lookup failed`);
+    return [];
+  }
+}
+
+async function resolveMx(name: string, errors: string[]): Promise<string[]> {
+  try {
+    const records = await dns.resolveMx(name);
+    return records
+      .sort((a, b) => a.priority - b.priority)
+      .map((record) => `${record.priority} ${record.exchange}`);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENODATA" || code === "ENOTFOUND" || code === "ENOENT") return [];
+    errors.push(`${name}: MX lookup failed`);
+    return [];
+  }
+}
+
+async function resolveCname(name: string, errors: string[]): Promise<string[]> {
+  try {
+    return await dns.resolveCname(name);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENODATA" || code === "ENOTFOUND" || code === "ENOENT") return [];
+    errors.push(`${name}: CNAME lookup failed`);
+    return [];
+  }
+}
+
+export async function POST(request: NextRequest) {
+  let body: RequestBody;
+  try {
+    body = (await request.json()) as RequestBody;
+  } catch {
+    return NextResponse.json({ error: "Send a JSON body with a domain." }, { status: 400 });
+  }
+
+  if (typeof body.domain !== "string") {
+    return NextResponse.json({ error: "Domain is required." }, { status: 400 });
+  }
+
+  try {
+    const domain = normalizeDomain(body.domain);
+    const dkimSelector = normalizeDkimSelector(
+      typeof body.dkimSelector === "string" ? body.dkimSelector : null,
+    );
+    const lookupErrors: string[] = [];
+    const dkimName = dkimSelector ? `${dkimSelector}._domainkey.${domain}` : null;
+
+    const [rootTxt, dmarcTxt, mxRecords, dkimTxtRecords, dkimCnameRecords] = await Promise.all([
+      resolveTxt(domain, lookupErrors),
+      resolveTxt(`_dmarc.${domain}`, lookupErrors),
+      resolveMx(domain, lookupErrors),
+      dkimName ? resolveTxt(dkimName, lookupErrors) : Promise.resolve([]),
+      dkimName ? resolveCname(dkimName, lookupErrors) : Promise.resolve([]),
+    ]);
+
+    return NextResponse.json(
+      analyzeEmailDnsRecords({
+        domain,
+        dkimSelector,
+        spfRecords: rootTxt,
+        dmarcRecords: dmarcTxt,
+        dkimTxtRecords,
+        dkimCnameRecords,
+        mxRecords,
+        lookupErrors,
+      }),
+    );
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 400 });
+  }
+}

--- a/src/app/deployment-review/page.tsx
+++ b/src/app/deployment-review/page.tsx
@@ -70,10 +70,11 @@ export default function DeploymentReviewPage() {
                 <ExternalLink className="h-4 w-4" />
               </a>
               <Link
-                href="#scope"
+                href="/tools/email-dns-checker"
                 className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-6 py-3 font-semibold text-gray-700 transition-colors hover:border-gray-300"
               >
-                <span>Review scope</span>
+                <MailCheck className="h-4 w-4" />
+                <span>Run DNS check</span>
               </Link>
             </div>
             <p className="mt-4 text-sm text-gray-500">

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -30,5 +30,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 0.7,
     },
+    {
+      url: `${baseUrl}/tools/email-dns-checker`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.75,
+    },
   ];
 }

--- a/src/app/tools/email-dns-checker/page.tsx
+++ b/src/app/tools/email-dns-checker/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import EmailDnsChecker from "@/components/EmailDnsChecker";
+import { deploymentReview, launchKit } from "@/config/launch-kit";
+
+export const metadata: Metadata = {
+  title: "Email DNS Readiness Checker",
+  description:
+    "Check SPF, DMARC, DKIM, and MX records before launching a FreeResend or Amazon SES sending domain.",
+  openGraph: {
+    title: "Email DNS Readiness Checker",
+    description: "Run a quick public DNS check before moving an SES sending domain into production.",
+    url: "https://www.freeresend.com/tools/email-dns-checker",
+    type: "website",
+  },
+};
+
+export default function EmailDnsCheckerPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-emerald-50">
+      <div className="border-b border-gray-100 bg-white/80 backdrop-blur-sm">
+        <nav className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
+          <Link href="/" className="text-sm font-semibold text-gray-700 hover:text-gray-950">
+            FreeResend
+          </Link>
+          <div className="flex items-center gap-4 text-sm font-medium">
+            <Link href={launchKit.productUrl} className="text-gray-600 hover:text-gray-950">
+              Launch Kit
+            </Link>
+            <Link href={deploymentReview.productUrl} className="text-gray-600 hover:text-gray-950">
+              Review
+            </Link>
+          </div>
+        </nav>
+      </div>
+      <EmailDnsChecker />
+    </main>
+  );
+}

--- a/src/components/EmailDnsChecker.tsx
+++ b/src/components/EmailDnsChecker.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { FormEvent, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ExternalLink,
+  Info,
+  Loader2,
+  MailCheck,
+  Search,
+  XCircle,
+} from "lucide-react";
+import { deploymentReview, launchKit } from "@/config/launch-kit";
+import type { EmailDnsAssessment, EmailDnsCheck, EmailDnsStatus } from "@/lib/email-dns-readiness";
+
+const statusStyles: Record<EmailDnsStatus, { label: string; icon: typeof CheckCircle2; className: string }> = {
+  pass: {
+    label: "Pass",
+    icon: CheckCircle2,
+    className: "border-emerald-200 bg-emerald-50 text-emerald-800",
+  },
+  warn: {
+    label: "Review",
+    icon: AlertTriangle,
+    className: "border-amber-200 bg-amber-50 text-amber-900",
+  },
+  fail: {
+    label: "Fix",
+    icon: XCircle,
+    className: "border-red-200 bg-red-50 text-red-800",
+  },
+  info: {
+    label: "Info",
+    icon: Info,
+    className: "border-blue-200 bg-blue-50 text-blue-800",
+  },
+};
+
+function StatusPill({ status }: { status: EmailDnsStatus }) {
+  const style = statusStyles[status];
+  const Icon = style.icon;
+
+  return (
+    <span className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-semibold ${style.className}`}>
+      <Icon className="h-3.5 w-3.5" />
+      {style.label}
+    </span>
+  );
+}
+
+function CheckCard({ check }: { check: EmailDnsCheck }) {
+  return (
+    <article className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900">{check.title}</h3>
+          <p className="mt-1 text-sm text-gray-600">{check.summary}</p>
+        </div>
+        <StatusPill status={check.status} />
+      </div>
+
+      <ul className="mt-4 space-y-2 text-sm leading-6 text-gray-600">
+        {check.details.map((detail) => (
+          <li key={detail} className="flex gap-2">
+            <span className="mt-2 h-1.5 w-1.5 flex-none rounded-full bg-gray-400" />
+            <span>{detail}</span>
+          </li>
+        ))}
+      </ul>
+
+      {check.records.length > 0 ? (
+        <div className="mt-4 overflow-hidden rounded-md border border-gray-100 bg-gray-50">
+          {check.records.map((record) => (
+            <code key={record} className="block break-words px-3 py-2 text-xs leading-5 text-gray-700">
+              {record}
+            </code>
+          ))}
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+export default function EmailDnsChecker() {
+  const [domain, setDomain] = useState("");
+  const [dkimSelector, setDkimSelector] = useState("");
+  const [result, setResult] = useState<EmailDnsAssessment | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const resultTitle = useMemo(() => {
+    if (!result) return "Check your sending domain";
+    if (result.overallStatus === "fail") return "Fix these records before launch";
+    if (result.overallStatus === "warn") return "Review these DNS warnings";
+    return "DNS looks ready for a closer launch pass";
+  }, [result]);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setLoading(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const response = await fetch("/api/tools/email-dns-checker", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ domain, dkimSelector }),
+      });
+      const payload = await response.json();
+
+      if (!response.ok) {
+        throw new Error(payload.error ?? "DNS check failed.");
+      }
+
+      setResult(payload as EmailDnsAssessment);
+    } catch (caught) {
+      setError((caught as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <section className="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
+      <div className="grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
+        <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+          <div className="mb-6 flex h-12 w-12 items-center justify-center rounded-lg bg-blue-50 text-blue-700">
+            <MailCheck className="h-6 w-6" />
+          </div>
+          <h1 className="text-3xl font-bold leading-tight text-gray-900 sm:text-4xl">
+            Email DNS readiness checker
+          </h1>
+          <p className="mt-4 leading-7 text-gray-600">
+            Check SPF, DMARC, MX, and one DKIM selector before moving a FreeResend or Amazon SES domain into production.
+          </p>
+
+          <form onSubmit={handleSubmit} className="mt-7 space-y-4">
+            <div>
+              <label htmlFor="domain" className="text-sm font-semibold text-gray-900">
+                Sending domain
+              </label>
+              <input
+                id="domain"
+                value={domain}
+                onChange={(event) => setDomain(event.target.value)}
+                placeholder="example.com"
+                className="mt-2 w-full rounded-lg border border-gray-300 px-4 py-3 text-gray-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+                autoComplete="off"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="dkimSelector" className="text-sm font-semibold text-gray-900">
+                DKIM selector
+              </label>
+              <input
+                id="dkimSelector"
+                value={dkimSelector}
+                onChange={(event) => setDkimSelector(event.target.value)}
+                placeholder="optional"
+                className="mt-2 w-full rounded-lg border border-gray-300 px-4 py-3 text-gray-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+                autoComplete="off"
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={loading}
+              className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-5 py-3 font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+            >
+              {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}
+              <span>{loading ? "Checking DNS" : "Run DNS check"}</span>
+            </button>
+          </form>
+
+          {error ? (
+            <p className="mt-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800">{error}</p>
+          ) : null}
+
+          <div className="mt-6 rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm leading-6 text-amber-900">
+            Never paste AWS keys, SMTP passwords, database URLs, or private tokens into this checker.
+          </div>
+        </div>
+
+        <div className="space-y-5">
+          <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-wide text-blue-700">
+                  {result?.domain ?? "FreeResend"}
+                </p>
+                <h2 className="mt-2 text-2xl font-bold text-gray-900">{resultTitle}</h2>
+                <p className="mt-2 leading-7 text-gray-600">
+                  {result?.summary ??
+                    "Run the checker to see the records that most often block SES launches, then use the launch kit or review offer for the remaining rollout work."}
+                </p>
+              </div>
+              {result ? <StatusPill status={result.overallStatus} /> : null}
+            </div>
+          </div>
+
+          {result ? (
+            <>
+              <div className="grid gap-4 md:grid-cols-2">
+                {result.checks.map((check) => (
+                  <CheckCard key={check.id} check={check} />
+                ))}
+              </div>
+
+              {result.lookupErrors.length > 0 ? (
+                <div className="rounded-lg border border-gray-200 bg-white p-4 text-sm text-gray-600">
+                  DNS lookup warnings: {result.lookupErrors.join("; ")}
+                </div>
+              ) : null}
+            </>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2">
+              {["SPF", "DMARC", "DKIM", "MX"].map((item) => (
+                <div key={item} className="rounded-lg border border-dashed border-gray-200 bg-white p-5 text-gray-500">
+                  <div className="h-2 w-16 rounded-full bg-gray-100" />
+                  <div className="mt-4 text-lg font-semibold text-gray-700">{item}</div>
+                  <div className="mt-3 h-2 w-full rounded-full bg-gray-100" />
+                  <div className="mt-2 h-2 w-2/3 rounded-full bg-gray-100" />
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-6">
+            <h2 className="text-xl font-bold text-emerald-950">Need a production pass?</h2>
+            <p className="mt-2 leading-7 text-emerald-900">
+              The checker only sees public DNS. The {deploymentReview.price} Deployment Review covers SES sandbox status,
+              region choice, DKIM alignment, webhook gaps, and the next launch fixes from your deployment URL.
+            </p>
+            <div className="mt-5 flex flex-col gap-3 sm:flex-row">
+              <a
+                href={deploymentReview.checkoutUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 rounded-lg bg-emerald-600 px-5 py-3 font-semibold text-white transition-colors hover:bg-emerald-700"
+              >
+                <span>Book review for {deploymentReview.price}</span>
+                <ExternalLink className="h-4 w-4" />
+              </a>
+              <a
+                href={launchKit.checkoutUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 rounded-lg border border-emerald-300 bg-white px-5 py-3 font-semibold text-emerald-800 transition-colors hover:bg-emerald-100"
+              >
+                <span>Buy launch kit</span>
+                <ExternalLink className="h-4 w-4" />
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -14,6 +14,7 @@ import {
   Github,
   Copy,
   CheckCircle,
+  MailCheck,
 } from "lucide-react";
 import EnvelopeIcon from "./EnvelopeIcon";
 import DeploymentReviewCta from "./DeploymentReviewCta";
@@ -60,6 +61,12 @@ export default function LandingPage() {
                 className="hidden text-gray-600 transition-colors hover:text-gray-900 md:inline"
               >
                 Launch Kit
+              </Link>
+              <Link
+                href="/tools/email-dns-checker"
+                className="hidden text-gray-600 transition-colors hover:text-gray-900 lg:inline"
+              >
+                DNS Check
               </Link>
               <Link
                 href={deploymentReview.productUrl}
@@ -139,6 +146,13 @@ export default function LandingPage() {
             >
               <BookOpenCheck className="h-5 w-5" />
               <span>Launch Kit</span>
+            </Link>
+            <Link
+              href="/tools/email-dns-checker"
+              className="border-2 border-gray-200 bg-white text-gray-700 px-8 py-4 rounded-lg hover:border-gray-300 transition-colors flex items-center justify-center space-x-2 font-semibold"
+            >
+              <MailCheck className="h-5 w-5" />
+              <span>DNS Check</span>
             </Link>
           </div>
           
@@ -530,6 +544,14 @@ export default function LandingPage() {
                     className="text-gray-400 hover:text-white transition-colors"
                   >
                     Deployment Review
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/tools/email-dns-checker"
+                    className="text-gray-400 hover:text-white transition-colors"
+                  >
+                    DNS Readiness Checker
                   </Link>
                 </li>
                 <li>

--- a/src/lib/__tests__/email-dns-readiness.test.ts
+++ b/src/lib/__tests__/email-dns-readiness.test.ts
@@ -1,0 +1,50 @@
+import {
+  analyzeEmailDnsRecords,
+  normalizeDkimSelector,
+  normalizeDomain,
+} from "../email-dns-readiness";
+
+describe("email DNS readiness", () => {
+  it("normalizes domains from URLs and email-style input", () => {
+    expect(normalizeDomain("https://Example.COM/path")).toBe("example.com");
+    expect(normalizeDomain("@mail.example.com.")).toBe("mail.example.com");
+  });
+
+  it("rejects invalid domains and selectors", () => {
+    expect(() => normalizeDomain("localhost")).toThrow("public domain");
+    expect(() => normalizeDomain("bad_domain.com")).toThrow("letters");
+    expect(() => normalizeDkimSelector("selector._domainkey")).toThrow("single DKIM selector");
+  });
+
+  it("flags blocking DNS launch risks", () => {
+    const assessment = analyzeEmailDnsRecords({
+      domain: "example.com",
+      dkimSelector: "selector1",
+      spfRecords: ["v=spf1 include:amazonses.com ~all", "v=spf1 include:_spf.example.com ~all"],
+      dmarcRecords: [],
+      dkimTxtRecords: [],
+      dkimCnameRecords: [],
+      mxRecords: [],
+    });
+
+    expect(assessment.overallStatus).toBe("fail");
+    expect(assessment.checks.find((check) => check.id === "spf")?.summary).toMatch(/Multiple SPF/);
+    expect(assessment.checks.find((check) => check.id === "dmarc")?.status).toBe("fail");
+    expect(assessment.checks.find((check) => check.id === "dkim")?.status).toBe("fail");
+  });
+
+  it("passes a domain with aligned public records", () => {
+    const assessment = analyzeEmailDnsRecords({
+      domain: "example.com",
+      dkimSelector: "abc123",
+      spfRecords: ["v=spf1 include:amazonses.com ~all"],
+      dmarcRecords: ["v=DMARC1; p=quarantine; rua=mailto:dmarc@example.com"],
+      dkimTxtRecords: [],
+      dkimCnameRecords: ["abc123.dkim.amazonses.com"],
+      mxRecords: ["10 inbound.example.com"],
+    });
+
+    expect(assessment.overallStatus).toBe("pass");
+    expect(assessment.checks.every((check) => check.status === "pass")).toBe(true);
+  });
+});

--- a/src/lib/email-dns-readiness.ts
+++ b/src/lib/email-dns-readiness.ts
@@ -1,0 +1,205 @@
+export type EmailDnsStatus = "pass" | "warn" | "fail" | "info";
+
+export type EmailDnsCheck = {
+  id: "spf" | "dmarc" | "dkim" | "mx";
+  title: string;
+  status: EmailDnsStatus;
+  summary: string;
+  details: string[];
+  records: string[];
+};
+
+export type EmailDnsAssessment = {
+  domain: string;
+  dkimSelector: string | null;
+  overallStatus: EmailDnsStatus;
+  summary: string;
+  checks: EmailDnsCheck[];
+  lookupErrors: string[];
+};
+
+export type EmailDnsRecords = {
+  domain: string;
+  dkimSelector?: string | null;
+  spfRecords: string[];
+  dmarcRecords: string[];
+  dkimTxtRecords: string[];
+  dkimCnameRecords: string[];
+  mxRecords: string[];
+  lookupErrors?: string[];
+};
+
+const statusRank: Record<EmailDnsStatus, number> = {
+  pass: 0,
+  info: 1,
+  warn: 2,
+  fail: 3,
+};
+
+function isValidDomainLabel(label: string): boolean {
+  return (
+    label.length > 0 &&
+    label.length <= 63 &&
+    !label.startsWith("-") &&
+    !label.endsWith("-") &&
+    /^[a-z0-9-]+$/.test(label)
+  );
+}
+
+export function normalizeDomain(input: string): string {
+  const stripped = input
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, "")
+    .replace(/^mailto:/, "")
+    .split(/[/?#]/)[0]
+    .replace(/^@/, "")
+    .replace(/\.$/, "");
+  const withoutPort = stripped.includes(":") ? stripped.split(":")[0] : stripped;
+  const labels = withoutPort.split(".");
+
+  if (withoutPort.length < 4 || withoutPort.length > 253 || labels.length < 2) {
+    throw new Error("Enter a public domain such as example.com.");
+  }
+
+  if (!labels.every(isValidDomainLabel)) {
+    throw new Error("Use only letters, numbers, hyphens, and dots in the domain.");
+  }
+
+  return withoutPort;
+}
+
+export function normalizeDkimSelector(input?: string | null): string | null {
+  if (!input) return null;
+  const selector = input.trim().toLowerCase().replace(/\.$/, "");
+  if (!selector) return null;
+
+  if (!isValidDomainLabel(selector)) {
+    throw new Error("Use a single DKIM selector label, such as selector1 or abc123.");
+  }
+
+  return selector;
+}
+
+function makeCheck(
+  id: EmailDnsCheck["id"],
+  title: string,
+  status: EmailDnsStatus,
+  summary: string,
+  details: string[],
+  records: string[],
+): EmailDnsCheck {
+  return { id, title, status, summary, details, records };
+}
+
+export function analyzeEmailDnsRecords(records: EmailDnsRecords): EmailDnsAssessment {
+  const spfRecords = records.spfRecords.filter((record) => /^v=spf1\b/i.test(record));
+  const dmarcRecords = records.dmarcRecords.filter((record) => /^v=dmarc1\b/i.test(record));
+  const hasDkim =
+    records.dkimTxtRecords.some((record) => /v=dkim1|p=/i.test(record)) ||
+    records.dkimCnameRecords.some((record) => /dkim|amazonses/i.test(record));
+
+  const checks: EmailDnsCheck[] = [];
+
+  if (spfRecords.length === 0) {
+    checks.push(
+      makeCheck("spf", "SPF", "warn", "No SPF record was found on the sending domain.", [
+        "SPF is not always enough for DMARC alignment, but it helps receivers evaluate allowed senders.",
+        "For Amazon SES custom MAIL FROM setups, confirm the required SPF value from your SES console.",
+      ], records.spfRecords),
+    );
+  } else if (spfRecords.length > 1) {
+    checks.push(
+      makeCheck("spf", "SPF", "fail", "Multiple SPF records were found.", [
+        "Receivers expect one SPF record. Merge the mechanisms into a single v=spf1 record before launch.",
+      ], spfRecords),
+    );
+  } else {
+    const includesSes = /amazonses\.com|amazonses/i.test(spfRecords[0]);
+    checks.push(
+      makeCheck("spf", "SPF", includesSes ? "pass" : "info", includesSes ? "SPF is present and mentions Amazon SES." : "SPF is present.", [
+        includesSes
+          ? "Confirm the sender domain and MAIL FROM domain match the SES setup you plan to use."
+          : "If SES provides a MAIL FROM SPF value for this domain, add it before production sending.",
+      ], spfRecords),
+    );
+  }
+
+  if (dmarcRecords.length === 0) {
+    checks.push(
+      makeCheck("dmarc", "DMARC", "fail", "No DMARC policy was found at _dmarc.", [
+        "Add a DMARC record before production so receivers know how to handle failed authentication.",
+      ], records.dmarcRecords),
+    );
+  } else if (dmarcRecords.length > 1) {
+    checks.push(
+      makeCheck("dmarc", "DMARC", "fail", "Multiple DMARC records were found.", [
+        "Receivers expect one DMARC record. Keep a single v=DMARC1 policy at _dmarc.",
+      ], dmarcRecords),
+    );
+  } else {
+    const policy = dmarcRecords[0].match(/;\s*p=([^;\s]+)/i)?.[1]?.toLowerCase();
+    checks.push(
+      makeCheck("dmarc", "DMARC", policy === "none" ? "warn" : "pass", policy === "none" ? "DMARC exists but is monitor-only." : "DMARC policy is present.", [
+        policy === "none"
+          ? "p=none is fine for rollout monitoring, but plan a move to quarantine or reject after mail flow is stable."
+          : `Current policy is p=${policy ?? "unspecified"}. Confirm this matches your rollout risk tolerance.`,
+      ], dmarcRecords),
+    );
+  }
+
+  if (!records.dkimSelector) {
+    checks.push(
+      makeCheck("dkim", "DKIM", "info", "No DKIM selector was checked.", [
+        "Enter one SES DKIM selector to verify the selector._domainkey record before sending production email.",
+      ], []),
+    );
+  } else if (hasDkim) {
+    checks.push(
+      makeCheck("dkim", "DKIM", "pass", `DKIM material was found for selector ${records.dkimSelector}.`, [
+        "Confirm this selector is one of the active DKIM tokens shown in Amazon SES for the sending identity.",
+      ], [...records.dkimTxtRecords, ...records.dkimCnameRecords]),
+    );
+  } else {
+    checks.push(
+      makeCheck("dkim", "DKIM", "fail", `No DKIM TXT or CNAME record was found for selector ${records.dkimSelector}.`, [
+        `Check ${records.dkimSelector}._domainkey.${records.domain} against the SES DKIM records before launch.`,
+      ], []),
+    );
+  }
+
+  if (records.mxRecords.length === 0) {
+    checks.push(
+      makeCheck("mx", "MX", "warn", "No MX records were found.", [
+        "Outbound sending can still work, but missing MX records can break replies, bounces, and some domain checks.",
+      ], []),
+    );
+  } else {
+    checks.push(
+      makeCheck("mx", "MX", "pass", "MX records are present.", [
+        "Confirm reply and bounce handling match the mailbox or SES receiving path you intend to use.",
+      ], records.mxRecords),
+    );
+  }
+
+  const overallStatus = checks.reduce<EmailDnsStatus>(
+    (worst, check) => (statusRank[check.status] > statusRank[worst] ? check.status : worst),
+    "pass",
+  );
+
+  const summary =
+    overallStatus === "fail"
+      ? "Fix the failed checks before sending production traffic."
+      : overallStatus === "warn"
+        ? "The domain is close, but warning items should be reviewed before launch."
+        : "No blocking DNS issues were detected by this quick check.";
+
+  return {
+    domain: records.domain,
+    dkimSelector: records.dkimSelector ?? null,
+    overallStatus,
+    summary,
+    checks,
+    lookupErrors: records.lookupErrors ?? [],
+  };
+}


### PR DESCRIPTION
## Summary
- add a free email DNS readiness checker for SPF, DMARC, DKIM, and MX records
- add a Node-backed DNS lookup API and shared record analysis helper
- route checker users toward the launch kit and Deployment Review offer
- promote the checker from homepage, deployment-review page, README, and sitemap

## Verification
- npm test -- src/lib/__tests__/email-dns-readiness.test.ts --runInBand
- npm run lint
- npm run build
- git diff --check
- local headless browser smoke for /tools/email-dns-checker, API POST, homepage link, and sitemap