### PR TITLE
Add SES production request helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ FreeResend allows you to host your own email service using Amazon SES and option
 
 > 📬 **Checking DNS before SES launch?** Run the free [Email DNS Readiness Checker](https://www.freeresend.com/tools/email-dns-checker) for SPF, DMARC, DKIM, and MX records before sending production traffic.
 
+> 📨 **Need SES production access?** Use the free [SES Production Request Helper](https://www.freeresend.com/tools/ses-production-request-helper) to draft a reviewer-friendly request without sharing secrets or customer data.
+
 ## Features
 
 - 🚀 **100% Resend-compatible** - True drop-in replacement using environment variables
@@ -411,6 +413,7 @@ MIT License - see LICENSE file for details.
 - 🧭 **Launch Kit**: Optional [$12 self-hosted deployment checklist](https://www.freeresend.com/launch-kit)
 - 🔎 **Deployment Review**: Optional [$12 one-page review of your SES, DNS, webhook, and launch-risk plan](https://www.freeresend.com/deployment-review)
 - 📬 **DNS Checker**: Free [email DNS readiness checker](https://www.freeresend.com/tools/email-dns-checker) for SPF, DMARC, DKIM, and MX records
+- 📨 **SES Request Helper**: Free [SES production access request draft helper](https://www.freeresend.com/tools/ses-production-request-helper) for a safe, public-data-only AWS support request
 - 🐛 **Issues**: Report bugs via [GitHub Issues](https://github.com/eibrahim/freeresend/issues)
 - 💡 **Feature Requests**: Suggest improvements via GitHub Issues
 - 🚀 **Professional Support**: Custom development and enterprise support available via [EliteCoders](https://elitecoders.co/)

--- a/src/app/guides/ses-production-readiness/page.tsx
+++ b/src/app/guides/ses-production-readiness/page.tsx
@@ -12,7 +12,7 @@ import {
   Siren,
   Workflow,
 } from "lucide-react";
-import { deploymentReview, launchKit, sesProductionGuide } from "@/config/launch-kit";
+import { deploymentReview, launchKit, sesProductionGuide, sesRequestHelper } from "@/config/launch-kit";
 
 export const metadata: Metadata = {
   title: "FreeResend SES Production Readiness Guide",
@@ -83,6 +83,9 @@ export default function SesProductionReadinessPage() {
             <Link href="/tools/email-dns-checker" className="text-gray-600 hover:text-gray-900">
               DNS checker
             </Link>
+            <Link href={sesRequestHelper.productUrl} className="text-gray-600 hover:text-gray-900">
+              SES request
+            </Link>
             <Link href={deploymentReview.productUrl} className="text-gray-600 hover:text-gray-900">
               Review
             </Link>
@@ -109,6 +112,13 @@ export default function SesProductionReadinessPage() {
               >
                 <MailCheck className="h-4 w-4" />
                 <span>Run DNS checker</span>
+              </Link>
+              <Link
+                href={sesRequestHelper.productUrl}
+                className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-6 py-3 font-semibold text-gray-700 transition-colors hover:border-gray-300"
+              >
+                <ClipboardCheck className="h-4 w-4" />
+                <span>Draft SES request</span>
               </Link>
               <a
                 href={deploymentReview.checkoutUrl}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -37,6 +37,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.75,
     },
     {
+      url: `${baseUrl}/tools/ses-production-request-helper`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.74,
+    },
+    {
       url: `${baseUrl}/guides/ses-production-readiness`,
       lastModified: now,
       changeFrequency: "monthly",

--- a/src/app/tools/ses-production-request-helper/page.tsx
+++ b/src/app/tools/ses-production-request-helper/page.tsx
@@ -1,23 +1,26 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import EmailDnsChecker from "@/components/EmailDnsChecker";
+import SesProductionRequestHelper from "@/components/SesProductionRequestHelper";
 import { deploymentReview, launchKit, sesProductionGuide, sesRequestHelper } from "@/config/launch-kit";
 
 export const metadata: Metadata = {
-  title: "Email DNS Readiness Checker",
+  title: "SES Production Request Helper",
   description:
-    "Check SPF, DMARC, DKIM, and MX records before launching a FreeResend or Amazon SES sending domain.",
+    "Draft a safe Amazon SES production access request for a FreeResend launch without sharing secrets or customer data.",
+  alternates: {
+    canonical: sesRequestHelper.canonicalUrl,
+  },
   openGraph: {
-    title: "Email DNS Readiness Checker",
-    description: "Run a quick public DNS check before moving an SES sending domain into production.",
-    url: "https://www.freeresend.com/tools/email-dns-checker",
+    title: "SES Production Request Helper",
+    description: "Generate a reviewer-friendly SES production access request from public rollout details.",
+    url: sesRequestHelper.canonicalUrl,
     type: "website",
   },
 };
 
-export default function EmailDnsCheckerPage() {
+export default function SesProductionRequestHelperPage() {
   return (
-    <main className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-emerald-50">
+    <main className="min-h-screen bg-gradient-to-br from-indigo-50 via-white to-emerald-50">
       <div className="border-b border-gray-100 bg-white/80 backdrop-blur-sm">
         <nav className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
           <Link href="/" className="text-sm font-semibold text-gray-700 hover:text-gray-950">
@@ -27,11 +30,11 @@ export default function EmailDnsCheckerPage() {
             <Link href={launchKit.productUrl} className="text-gray-600 hover:text-gray-950">
               Launch Kit
             </Link>
+            <Link href="/tools/email-dns-checker" className="text-gray-600 hover:text-gray-950">
+              DNS
+            </Link>
             <Link href={sesProductionGuide.productUrl} className="text-gray-600 hover:text-gray-950">
               Guide
-            </Link>
-            <Link href={sesRequestHelper.productUrl} className="text-gray-600 hover:text-gray-950">
-              SES request
             </Link>
             <Link href={deploymentReview.productUrl} className="text-gray-600 hover:text-gray-950">
               Review
@@ -39,7 +42,7 @@ export default function EmailDnsCheckerPage() {
           </div>
         </nav>
       </div>
-      <EmailDnsChecker />
+      <SesProductionRequestHelper />
     </main>
   );
 }

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -15,11 +15,12 @@ import {
   Copy,
   CheckCircle,
   MailCheck,
+  FileText,
 } from "lucide-react";
 import EnvelopeIcon from "./EnvelopeIcon";
 import DeploymentReviewCta from "./DeploymentReviewCta";
 import LaunchKitCta from "./LaunchKitCta";
-import { deploymentReview, launchKit, sesProductionGuide } from "@/config/launch-kit";
+import { deploymentReview, launchKit, sesProductionGuide, sesRequestHelper } from "@/config/launch-kit";
 
 export default function LandingPage() {
   const [copiedCode, setCopiedCode] = useState(false);
@@ -73,6 +74,12 @@ export default function LandingPage() {
                 className="hidden text-gray-600 transition-colors hover:text-gray-900 lg:inline"
               >
                 DNS Check
+              </Link>
+              <Link
+                href={sesRequestHelper.productUrl}
+                className="hidden text-gray-600 transition-colors hover:text-gray-900 xl:inline"
+              >
+                SES Request
               </Link>
               <Link
                 href={deploymentReview.productUrl}
@@ -160,6 +167,13 @@ export default function LandingPage() {
               <MailCheck className="h-5 w-5" />
               <span>DNS Check</span>
             </Link>
+            <Link
+              href={sesRequestHelper.productUrl}
+              className="border-2 border-gray-200 bg-white text-gray-700 px-8 py-4 rounded-lg hover:border-gray-300 transition-colors flex items-center justify-center space-x-2 font-semibold"
+            >
+              <FileText className="h-5 w-5" />
+              <span>SES Request</span>
+            </Link>
           </div>
           
           <div className="text-center mb-8">
@@ -226,6 +240,26 @@ export default function LandingPage() {
               >
                 <BookOpenCheck className="h-5 w-5" />
                 <span>Read guide</span>
+              </Link>
+            </div>
+          </div>
+
+          <div className="mx-auto mb-12 max-w-4xl rounded-lg border border-indigo-100 bg-white p-6 text-left shadow-sm">
+            <div className="grid gap-5 lg:grid-cols-[1fr_auto] lg:items-center">
+              <div>
+                <p className="text-sm font-medium uppercase tracking-wide text-indigo-700">SES access request</p>
+                <h3 className="mt-2 text-2xl font-bold text-gray-900">Draft the production request without secrets.</h3>
+                <p className="mt-3 text-gray-600">
+                  Turn public domain, volume, opt-in, bounce, and complaint details into an AWS reviewer-friendly SES
+                  production access request.
+                </p>
+              </div>
+              <Link
+                href={sesRequestHelper.productUrl}
+                className="inline-flex items-center justify-center space-x-2 rounded-lg bg-indigo-600 px-5 py-3 font-semibold text-white transition-colors hover:bg-indigo-700"
+              >
+                <FileText className="h-5 w-5" />
+                <span>Draft request</span>
               </Link>
             </div>
           </div>
@@ -586,6 +620,14 @@ export default function LandingPage() {
                     className="text-gray-400 hover:text-white transition-colors"
                   >
                     DNS Readiness Checker
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href={sesRequestHelper.productUrl}
+                    className="text-gray-400 hover:text-white transition-colors"
+                  >
+                    SES Request Helper
                   </Link>
                 </li>
                 <li>

--- a/src/components/SesProductionRequestHelper.tsx
+++ b/src/components/SesProductionRequestHelper.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { FormEvent, useMemo, useState } from "react";
+import { Check, Clipboard, ExternalLink, FileText, ShieldCheck } from "lucide-react";
+import { deploymentReview, launchKit } from "@/config/launch-kit";
+import { buildSesProductionRequest, type SesProductionRequestInput } from "@/lib/ses-production-request";
+
+const initialInput: SesProductionRequestInput = {
+  sendingDomain: "",
+  websiteUrl: "",
+  region: "us-east-1",
+  useCase: "",
+  expectedVolume: "",
+  optInSource: "",
+  bounceHandling: "",
+  complaintHandling: "",
+};
+
+export default function SesProductionRequestHelper() {
+  const [input, setInput] = useState<SesProductionRequestInput>(initialInput);
+  const [submittedInput, setSubmittedInput] = useState<SesProductionRequestInput | null>(null);
+  const [copied, setCopied] = useState<"subject" | "body" | null>(null);
+
+  const request = useMemo(
+    () => buildSesProductionRequest(submittedInput ?? input),
+    [input, submittedInput]
+  );
+
+  function updateInput(field: keyof SesProductionRequestInput, value: string) {
+    setInput((current) => ({ ...current, [field]: value }));
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSubmittedInput(input);
+  }
+
+  async function copyText(kind: "subject" | "body", value: string) {
+    await navigator.clipboard.writeText(value);
+    setCopied(kind);
+    window.setTimeout(() => setCopied(null), 1800);
+  }
+
+  return (
+    <section className="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
+      <div className="grid gap-8 lg:grid-cols-[0.92fr_1.08fr] lg:items-start">
+        <form onSubmit={handleSubmit} className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+          <div className="mb-6 flex h-12 w-12 items-center justify-center rounded-lg bg-indigo-50 text-indigo-700">
+            <FileText className="h-6 w-6" />
+          </div>
+          <h1 className="text-3xl font-bold leading-tight text-gray-900 sm:text-4xl">
+            SES production request helper
+          </h1>
+          <p className="mt-4 leading-7 text-gray-600">
+            Draft the Amazon SES production access request from public rollout details before a FreeResend launch.
+          </p>
+
+          <div className="mt-7 grid gap-4">
+            <Field
+              id="sendingDomain"
+              label="Sending domain"
+              placeholder="example.com"
+              value={input.sendingDomain}
+              onChange={(value) => updateInput("sendingDomain", value)}
+              required
+            />
+            <Field
+              id="websiteUrl"
+              label="Website or app URL"
+              placeholder="https://example.com"
+              value={input.websiteUrl}
+              onChange={(value) => updateInput("websiteUrl", value)}
+            />
+            <Field
+              id="region"
+              label="AWS region"
+              placeholder="us-east-1"
+              value={input.region}
+              onChange={(value) => updateInput("region", value)}
+              required
+            />
+            <TextArea
+              id="useCase"
+              label="Use case"
+              placeholder="Password resets, login codes, invoices, and account notifications"
+              value={input.useCase}
+              onChange={(value) => updateInput("useCase", value)}
+            />
+            <Field
+              id="expectedVolume"
+              label="Expected volume"
+              placeholder="2,000 messages per month with gradual ramp-up"
+              value={input.expectedVolume}
+              onChange={(value) => updateInput("expectedVolume", value)}
+            />
+            <TextArea
+              id="optInSource"
+              label="Recipient opt-in/source"
+              placeholder="Only registered users who request account email"
+              value={input.optInSource}
+              onChange={(value) => updateInput("optInSource", value)}
+            />
+            <TextArea
+              id="bounceHandling"
+              label="Bounce handling"
+              placeholder="SNS webhook into FreeResend bounce handler"
+              value={input.bounceHandling}
+              onChange={(value) => updateInput("bounceHandling", value)}
+            />
+            <TextArea
+              id="complaintHandling"
+              label="Complaint handling"
+              placeholder="SNS complaint webhook with suppression"
+              value={input.complaintHandling}
+              onChange={(value) => updateInput("complaintHandling", value)}
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-indigo-600 px-5 py-3 font-semibold text-white transition-colors hover:bg-indigo-700"
+          >
+            <FileText className="h-4 w-4" />
+            <span>Generate request</span>
+          </button>
+
+          <div className="mt-5 rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm leading-6 text-amber-900">
+            Do not paste AWS keys, SMTP passwords, customer lists, private logs, or customer data into this tool.
+          </div>
+        </form>
+
+        <div className="space-y-5">
+          <article className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-wide text-indigo-700">Draft output</p>
+                <h2 className="mt-2 text-2xl font-bold text-gray-900">{request.subject}</h2>
+              </div>
+              <button
+                type="button"
+                onClick={() => copyText("subject", request.subject)}
+                className="inline-flex items-center gap-2 rounded-lg border border-gray-200 px-3 py-2 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-50"
+              >
+                {copied === "subject" ? <Check className="h-4 w-4" /> : <Clipboard className="h-4 w-4" />}
+                <span>Copy subject</span>
+              </button>
+            </div>
+            <pre className="mt-5 max-h-[560px] overflow-auto whitespace-pre-wrap rounded-lg border border-gray-100 bg-gray-950 p-4 text-sm leading-6 text-gray-100">
+              {request.body}
+            </pre>
+            <button
+              type="button"
+              onClick={() => copyText("body", request.body)}
+              className="mt-4 inline-flex items-center gap-2 rounded-lg bg-gray-900 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-gray-800"
+            >
+              {copied === "body" ? <Check className="h-4 w-4" /> : <Clipboard className="h-4 w-4" />}
+              <span>Copy request body</span>
+            </button>
+          </article>
+
+          <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-6">
+            <div className="flex gap-3">
+              <ShieldCheck className="mt-1 h-5 w-5 flex-none text-emerald-700" />
+              <div>
+                <h2 className="text-xl font-bold text-emerald-950">Want the rollout checked first?</h2>
+                <p className="mt-2 leading-7 text-emerald-900">
+                  The {deploymentReview.price} Deployment Review covers SES sandbox status, region choice, DNS, webhook
+                  handling, and smoke-test gaps before you send production traffic.
+                </p>
+              </div>
+            </div>
+            <div className="mt-5 flex flex-col gap-3 sm:flex-row">
+              <a
+                href={deploymentReview.checkoutUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 rounded-lg bg-emerald-600 px-5 py-3 font-semibold text-white transition-colors hover:bg-emerald-700"
+              >
+                <span>Book deployment review</span>
+                <ExternalLink className="h-4 w-4" />
+              </a>
+              <a
+                href={launchKit.checkoutUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 rounded-lg border border-emerald-300 bg-white px-5 py-3 font-semibold text-emerald-800 transition-colors hover:bg-emerald-100"
+              >
+                <span>Buy launch kit</span>
+                <ExternalLink className="h-4 w-4" />
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Field({
+  id,
+  label,
+  placeholder,
+  value,
+  onChange,
+  required = false,
+}: {
+  id: string;
+  label: string;
+  placeholder: string;
+  value: string;
+  onChange: (value: string) => void;
+  required?: boolean;
+}) {
+  return (
+    <div>
+      <label htmlFor={id} className="text-sm font-semibold text-gray-900">
+        {label}
+      </label>
+      <input
+        id={id}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        required={required}
+        className="mt-2 w-full rounded-lg border border-gray-300 px-4 py-3 text-gray-900 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-100"
+      />
+    </div>
+  );
+}
+
+function TextArea({
+  id,
+  label,
+  placeholder,
+  value,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  placeholder: string;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div>
+      <label htmlFor={id} className="text-sm font-semibold text-gray-900">
+        {label}
+      </label>
+      <textarea
+        id={id}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        rows={3}
+        className="mt-2 w-full resize-y rounded-lg border border-gray-300 px-4 py-3 text-gray-900 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-100"
+      />
+    </div>
+  );
+}

--- a/src/components/__tests__/SesProductionRequestHelper.test.tsx
+++ b/src/components/__tests__/SesProductionRequestHelper.test.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import SesProductionRequestHelper from "../SesProductionRequestHelper";
+
+describe("SesProductionRequestHelper", () => {
+  it("generates a production request from buyer-safe public inputs", async () => {
+    render(<SesProductionRequestHelper />);
+
+    await userEvent.type(screen.getByLabelText(/sending domain/i), "example.com");
+    await userEvent.type(screen.getByLabelText(/website or app url/i), "https://example.com");
+    await userEvent.type(screen.getByLabelText(/use case/i), "Password resets and account notifications");
+    await userEvent.click(screen.getByRole("button", { name: /generate request/i }));
+
+    expect(screen.getByText(/request production access for amazon ses in us-east-1/i)).toBeInTheDocument();
+    expect(screen.getByText(/sending domain: example.com/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/password resets and account notifications/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole("link", { name: /book deployment review/i })).toHaveAttribute(
+      "href",
+      "https://buy.stripe.com/3cIcN49zBcRagx5dvXaMU01"
+    );
+  });
+});

--- a/src/config/launch-kit.ts
+++ b/src/config/launch-kit.ts
@@ -37,3 +37,9 @@ export const sesProductionGuide = {
   productUrl: "/guides/ses-production-readiness",
   canonicalUrl: "https://www.freeresend.com/guides/ses-production-readiness",
 } as const;
+
+export const sesRequestHelper = {
+  name: "SES Production Request Helper",
+  productUrl: "/tools/ses-production-request-helper",
+  canonicalUrl: "https://www.freeresend.com/tools/ses-production-request-helper",
+} as const;

--- a/src/lib/__tests__/ses-production-request.test.ts
+++ b/src/lib/__tests__/ses-production-request.test.ts
@@ -1,0 +1,42 @@
+import { buildSesProductionRequest, normalizeSesProductionRequestInput } from "../ses-production-request";
+
+describe("SES production request helper", () => {
+  it("normalizes blank optional fields into reviewer-friendly defaults", () => {
+    const input = normalizeSesProductionRequestInput({
+      sendingDomain: " Mail.Example.COM ",
+      websiteUrl: "",
+      region: " us-east-1 ",
+      useCase: "",
+      expectedVolume: "",
+      optInSource: "",
+      bounceHandling: "",
+      complaintHandling: "",
+    });
+
+    expect(input.sendingDomain).toBe("mail.example.com");
+    expect(input.websiteUrl).toBe("Not provided");
+    expect(input.useCase).toBe("Transactional application email");
+    expect(input.expectedVolume).toBe("Low initial production volume with gradual ramp-up");
+  });
+
+  it("builds a production-access request without asking for secrets", () => {
+    const request = buildSesProductionRequest({
+      sendingDomain: "example.com",
+      websiteUrl: "https://example.com",
+      region: "us-east-1",
+      useCase: "Password resets and account notifications",
+      expectedVolume: "2,000 messages per month",
+      optInSource: "Only registered users who request account email",
+      bounceHandling: "SNS webhook into FreeResend bounce handler",
+      complaintHandling: "SNS complaint webhook with suppression",
+    });
+
+    expect(request.subject).toBe("Request production access for Amazon SES in us-east-1");
+    expect(request.body).toContain("Sending domain: example.com");
+    expect(request.body).toContain("Use case: Password resets and account notifications");
+    expect(request.body).toContain("Bounce handling: SNS webhook into FreeResend bounce handler");
+    expect(request.body).toContain("Complaint handling: SNS complaint webhook with suppression");
+    expect(request.body).toContain("I am not including AWS access keys, SMTP passwords, or customer data in this request.");
+    expect(request.body).not.toContain("SECRET_ACCESS_KEY");
+  });
+});

--- a/src/lib/ses-production-request.ts
+++ b/src/lib/ses-production-request.ts
@@ -1,0 +1,84 @@
+export type SesProductionRequestInput = {
+  sendingDomain: string;
+  websiteUrl: string;
+  region: string;
+  useCase: string;
+  expectedVolume: string;
+  optInSource: string;
+  bounceHandling: string;
+  complaintHandling: string;
+};
+
+export type SesProductionRequest = {
+  subject: string;
+  body: string;
+};
+
+const defaults = {
+  websiteUrl: "Not provided",
+  region: "us-east-1",
+  useCase: "Transactional application email",
+  expectedVolume: "Low initial production volume with gradual ramp-up",
+  optInSource: "Only opted-in or account-related recipients",
+  bounceHandling: "Amazon SNS bounce notifications routed to the application suppression workflow",
+  complaintHandling: "Amazon SNS complaint notifications routed to suppression and follow-up review",
+};
+
+function clean(value: string | undefined, fallback: string) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : fallback;
+}
+
+function cleanDomain(value: string) {
+  return value
+    .trim()
+    .replace(/^https?:\/\//i, "")
+    .replace(/^@/, "")
+    .replace(/\/.*$/, "")
+    .replace(/\.$/, "")
+    .toLowerCase();
+}
+
+export function normalizeSesProductionRequestInput(input: SesProductionRequestInput): SesProductionRequestInput {
+  return {
+    sendingDomain: cleanDomain(input.sendingDomain),
+    websiteUrl: clean(input.websiteUrl, defaults.websiteUrl),
+    region: clean(input.region, defaults.region),
+    useCase: clean(input.useCase, defaults.useCase),
+    expectedVolume: clean(input.expectedVolume, defaults.expectedVolume),
+    optInSource: clean(input.optInSource, defaults.optInSource),
+    bounceHandling: clean(input.bounceHandling, defaults.bounceHandling),
+    complaintHandling: clean(input.complaintHandling, defaults.complaintHandling),
+  };
+}
+
+export function buildSesProductionRequest(input: SesProductionRequestInput): SesProductionRequest {
+  const normalized = normalizeSesProductionRequestInput(input);
+  const subject = `Request production access for Amazon SES in ${normalized.region}`;
+  const body = [
+    "Hello AWS SES team,",
+    "",
+    "I am requesting production access for Amazon SES so this account can send transactional email through a self-hosted FreeResend deployment.",
+    "",
+    `Sending domain: ${normalized.sendingDomain}`,
+    `Website or app URL: ${normalized.websiteUrl}`,
+    `AWS region: ${normalized.region}`,
+    `Use case: ${normalized.useCase}`,
+    `Expected volume: ${normalized.expectedVolume}`,
+    `Recipient opt-in/source: ${normalized.optInSource}`,
+    `Bounce handling: ${normalized.bounceHandling}`,
+    `Complaint handling: ${normalized.complaintHandling}`,
+    "",
+    "Operational controls:",
+    "- SPF, DKIM, and DMARC will be configured before production sending.",
+    "- Bounces and complaints will be monitored and suppressed before additional sends.",
+    "- Mailing lists will not be purchased, scraped, or imported from unverified sources.",
+    "- Sending will start at low volume and ramp only after delivery and complaint rates are healthy.",
+    "",
+    "I am not including AWS access keys, SMTP passwords, or customer data in this request.",
+    "",
+    "Thank you.",
+  ].join("\n");
+
+  return { subject, body };
+}


### PR DESCRIPTION
## Summary
- add a free SES production request helper tool
- link the helper from the homepage, SES guide, DNS checker, README, and sitemap
- include tests for the generated AWS SES request and the UI flow

## Verification
- npm test -- src/lib/__tests__/ses-production-request.test.ts src/components/__tests__/SesProductionRequestHelper.test.tsx --runInBand
- npm test -- src/components/__tests__/LandingPage.test.tsx --runInBand
- npm run lint
- npm run build
- git diff --check
- local browser verification for helper form, homepage/guide links, sitemap, and desktop/mobile overflow